### PR TITLE
Custom configuration for our ECR cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,29 @@ It can clean up a specific repository as well as all repos within an aws account
 6. Delete images from the repository
 
 ### Installation (Not Used)
-    go get github.com/WeltN24/ecr-cleaner
+    go get github.com/bandsintown/ecr-cleaner
 
 ### Default values
-    aws.region = eu-central-1
+    aws.region = us-east-1
     dry-run = false
     keep = 100
 
 ### Examples
 clean up all repos
 
-`ecr-cleaner -aws.region=eu-west-1`
+`ecr-cleaner -aws.region=us-east-1`
 
 clean up my-awesome-repo
 
-`ecr-cleaner -aws.region=eu-west-1 -repo=my-awesome-repo`
+`ecr-cleaner -aws.region=us-east-1 -repo=my-awesome-repo`
 
 go for a dry run
 
-`ecr-cleaner -aws.region=eu-west-1 -repo=my-awesome-repo -dry-run=true`
+`ecr-cleaner -aws.region=us-east-1 -repo=my-awesome-repo -dry-run=true`
 
 leave n images in repo
 
-`ecr-cleaner -aws.region=eu-west-1 -repo=my-awesome-repo -keep=5`
+`ecr-cleaner -aws.region=us-east-1 -repo=my-awesome-repo -keep=5`
 
 **Note**: Most of the parameters could be specified without '=' sign.
 But because of the usage of [parse flag](https://golang.org/pkg/flag/) it is
@@ -79,4 +79,4 @@ Build:
 
 Run:
 
-	docker run -e AWS_ACCESS_KEY_ID=<your-access-key-id> -e AWS_SECRET_ACCESS_KEY=<your-secret-access-key> -it --rm ecr-cleaner -dry-run=true -aws.region=eu-west-1
+	docker run -e AWS_ACCESS_KEY_ID=<your-access-key-id> -e AWS_SECRET_ACCESS_KEY=<your-secret-access-key> -it --rm ecr-cleaner -dry-run=true -aws.region=us-east-1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It can clean up a specific repository as well as all repos within an aws account
 5. Add n oldest images to deletion
 6. Delete images from the repository
 
-### Installation
+### Installation (Not Used)
     go get github.com/WeltN24/ecr-cleaner
 
 ### Default values
@@ -41,21 +41,22 @@ But because of the usage of [parse flag](https://golang.org/pkg/flag/) it is
 important to think about adding '=' signs for boolean parameters, otherwise the
 parsing of the command line's options stops. [Issue hilighted here.](https://github.com/WeltN24/ecr-cleaner/issues/5)
 
-### Deploying as lambda to aws
+### Deploying as lambda to aws (Used)
 
 If you wish to clean up your repositories periodically you can do this with the help of terraform.
 In the root of the repo:
 
 1. you have to fork the repo
-2. execute `make package`
-3. go to into terraform folder
-4. set up the needed variables
+1. execute `make package`
+1. go to into terraform folder
+1. run the `init.sh` script, it will initialize terraform
+1. set up the needed variables
     * `cron` expects a string in [aws cron syntaxt](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html) (`0 3 1 * ? *` run lambda at 3am 1. of each month)
     * `aws_region` is the region in which you want to deploy the lambda
     * `repo_region` is the region in which you store your ec2 repositories
     * `repository` is the repo you want to process
     * `dry-run` (boolean) if you want to dry run
-5. run terraform
+1. run terraform
 
 If you want to keep the state, the easiest way is to create a shell script and write the remote state to s3.
 Here is an example:
@@ -64,13 +65,13 @@ Here is an example:
     terraform get -update
     terraform remote config \
         -backend=s3\
-        -backend-config="bucket=maintaince" \
-        -backend-config="key=ecr_cleaner/terraform.tfstate" \
-        -backend-config="region=eu-central-1"
+        -backend-config="bucket=bit-ops-terraform" \
+        -backend-config="key=state/service/ecr-cleanup/ops.tfstate" \
+        -backend-config="region=us-east-1"
 
 Execute the script: get remote state from s3 or create one and execute terraform afterwards.
 
-### Run as Docker container
+### Run as Docker container (Not Used)
 
 Build:
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+cd ${PWD}/terraform
+terraform init -backend-config="region=us-east-1" -backend-config="bucket=bit-ops-terraform" -backend-config="key=state/service/ecr-cleanup/ops.tfstate"

--- a/terraform/event_json.json
+++ b/terraform/event_json.json
@@ -8,7 +8,7 @@
     "value": "${dry_run}"
   },
   {
-    "name": "-repository",
-    "value": "${repository}"
+    "name": "-keep",
+    "value": "${keep}"
   }
 ]

--- a/terraform/event_rule.tf
+++ b/terraform/event_rule.tf
@@ -16,6 +16,6 @@ data "template_file" "event_json" {
   vars = {
     aws_region = "${var.repo_region}"
     dry_run    = "${var.dry_run}"
-    repository = "${var.repository}"
+    keep       = "${var.keep}"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,15 +1,20 @@
 variable "aws_region" {
-  default = "eu-central-1"
+  default = "us-east-1"
 }
 
-variable "cron" {}
+variable "keep" {
+  default="100"
+}
 
-variable "repository" {
-  default = ""
+variable "cron" {
+  default="0 * * * ? *"
 }
 
 variable "dry_run" {
-  default = ""
+  default = "true"
 }
 
-variable "repo_region" {}
+variable "repo_region" {
+   default="us-east-1"
+}
+


### PR DESCRIPTION
Terraform option was configured to clean up the registry.
An init script was created to initialized terraform configuration.
The repositories variable was remove so the lambda function will clean all repositories it finds in the registry.
The keep variable was included to be able to define how many images we want to keep for each repository.
The dry-run was set to true so with the first execution it wont delete any image and we'll be able to see the behaviour of the tool.
Documentation was updated accordingly